### PR TITLE
fix: return statement and correct update

### DIFF
--- a/src/lambda/rest.eventmgmtapi.updateEventParticipant.ts
+++ b/src/lambda/rest.eventmgmtapi.updateEventParticipant.ts
@@ -14,13 +14,13 @@ export const handler = api.createOpenApiHandlerWithRequestBody<operations['updat
     throw new errors.NotFoundError();
   }
 
-  await Participant.update({
+  return await Participant.update({
     eventId: eventId,
+    participantId: participantId,
     email: participant.email,
     name: data.name,
     displayName: data.displayName,
     customData: JSON.stringify(data.customData),
   });
 
-  return new Promise<never>(() => {});
 });

--- a/src/lambda/rest.eventmgmtapi.updateEventParticipant.ts
+++ b/src/lambda/rest.eventmgmtapi.updateEventParticipant.ts
@@ -14,7 +14,7 @@ export const handler = api.createOpenApiHandlerWithRequestBody<operations['updat
     throw new errors.NotFoundError();
   }
 
-  return await Participant.update({
+  return Participant.update({
     eventId: eventId,
     participantId: participantId,
     email: participant.email,


### PR DESCRIPTION
This fixes the following error:
```json
{
    "_logLevel": "error",
    "msg": "Get without sort key returns more than one result",
    "stack": "OneTableError: Get without sort key returns more than one result\n    at Model.get (/var/task/index.js:30183:15)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Model.updateUnique (/var/task/index.js:30333:17)\n    at async Model.update (/var/task/index.js:30305:16)\n    at async /var/task/index.js:34178:3\n    at async Runtime.handler (/var/task/index.js:28878:23)",
    "requestId": "615aad06-c18c-49f1-bb5f-e668508beff0",
    "_tags": []
}
```

It also returns the updated object