### PR TITLE
feat(email): add FAQ link to registration confirmation email

### DIFF
--- a/mail-templates/confirm-registration.html
+++ b/mail-templates/confirm-registration.html
@@ -3,4 +3,6 @@
 <p></p>
 <p>To view or modify your registration please visit <a href="{{websiteUrl}}/events/{{event.id}}/participants/{{participant.participantId}}?email={{participant.email}}">this page</a></p>
 <p></p>
+<p>We also curated a list of frequently asked questions. Please review them here: <a href="https://www.aws-community-day.de/faq">FAQ Page</a></p>
+<p></p>
 <p>Your events team</p>


### PR DESCRIPTION
Added a section in the registration confirmation email template directing users to a curated FAQ page. This aims to reduce common inquiries and improve user experience by providing immediate access to frequently needed information.
